### PR TITLE
Feature: Sign in with Provider

### DIFF
--- a/Sources/SkipSupabase/SupabaseAuth.swift
+++ b/Sources/SkipSupabase/SupabaseAuth.swift
@@ -16,6 +16,12 @@ import io.github.jan.supabase.auth.minimalSettings
 
 #if SKIP
 
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
 // SKIP NOWARN
 // This extension will be moved into its extended type definition when translated to Kotlin. It will not be able to access this file's private types or fileprivate members
 extension SupabaseClient {
@@ -143,12 +149,33 @@ public class AuthClient {
             }
         }
 
-        // If a session was created synchronously, return it; otherwise indicate the flow requires a redirect or is incomplete.
+        // If a session was created synchronously, return it; otherwise attempt to open
+        // the redirect URL in the system browser when available and indicate the flow
+        // requires a redirect by returning nil in the completion.
         if let s = auth.currentSessionOrNull() {
             completion(Session(session: s))
         } else {
+            if let redirect = redirectToWithParams {
+                openURL(redirect)
+            }
             completion(nil)
         }
+    }
+
+    // Open a URL in the system browser or via the platform's APIs. This is best-effort
+    // and intended for use when an OAuth provider flow requires a redirect.
+    fileprivate func openURL(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        #if canImport(UIKit)
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        #elseif canImport(AppKit)
+        NSWorkspace.shared.open(url)
+        #else
+        // Fallback: print the URL so calling apps can handle it.
+        print("Open URL: \(url.absoluteString)")
+        #endif
     }
 
     public func signOut(scope: SignOutScope = .global) async throws {

--- a/Sources/SkipSupabase/SupabaseAuth.swift
+++ b/Sources/SkipSupabase/SupabaseAuth.swift
@@ -79,6 +79,18 @@ public class AuthClient {
         try await auth.signInAnonymously(data: dict2JsonObject(data), captchaToken: captchaToken)
     }
 
+    /// Sign in using an external OAuth provider (Google, GitHub, Apple, etc.).
+    /// This is a platform-specific flow and may open a browser or use a native SDK.
+    /// The completion handler receives a Session if the sign-in completes immediately, or nil
+    /// if the flow requires a redirect or is not available on the current platform.
+    public func signInWithOAuth(provider: Provider, redirectTo: String? = nil, scopes: String = "", queryParams: [(name: String, value: String)] = [], completion: @escaping (Session?) -> Void) async throws {
+        // SKIP NOWARN
+        // Attempt to call through to the underlying Kotlin auth API if available.
+        // For the SKIP shim, provide a safe stub: call completion(nil). Real platform implementations
+        // should call the Kotlin/JS/Native provider API and invoke completion with the resulting session.
+        completion(nil)
+    }
+
     public func signOut(scope: SignOutScope = .global) async throws {
         // SKIP NOWARN
         try await auth.signOut(scope.kotlinScope)
@@ -128,6 +140,15 @@ public struct UserAttributes: Sendable {
         self.phone = phone
         self.password = password
     }
+}
+
+/// OAuth providers that can be used with signInWithOAuth. Add providers as needed.
+public enum Provider: String, Sendable {
+    case google
+    case github
+    case apple
+    case gitlab
+    case bitbucket
 }
 
 public enum SignOutScope: String, Sendable {

--- a/Sources/SkipSupabase/SupabaseAuth.swift
+++ b/Sources/SkipSupabase/SupabaseAuth.swift
@@ -85,32 +85,60 @@ public class AuthClient {
     /// if the flow requires a redirect or is not available on the current platform.
     public func signInWithOAuth(provider: Provider, redirectTo: String? = nil, scopes: String = "", queryParams: [(name: String, value: String)] = [], completion: @escaping (Session?) -> Void) async throws {
         // SKIP NOWARN
-        // Map Provider to Kotlin provider object and invoke signInWith builder when available.
+        // Build redirectTo with encoded query params if provided. This avoids depending on
+        // platform-specific builder features and keeps query params attached to the redirect URL.
+        var redirectToWithParams: String? = nil
+        if let redirectTo = redirectTo {
+            if queryParams.isEmpty {
+                redirectToWithParams = redirectTo
+            } else {
+                let encodedPairs = queryParams.compactMap { pair -> String? in
+                    guard let name = pair.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                          let value = pair.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
+                    return "\(name)=\(value)"
+                }
+                if !encodedPairs.isEmpty {
+                    let separator = redirectTo.contains("?") ? "&" : "?"
+                    redirectToWithParams = redirectTo + separator + encodedPairs.joined(separator: "&")
+                } else {
+                    redirectToWithParams = redirectTo
+                }
+            }
+        } else if !queryParams.isEmpty {
+            // No redirectTo provided but query params exist — platform-specific flows may require a redirect URL.
+            // For now leave redirectToWithParams nil and document TODO for platform wiring.
+            // TODO: Consider constructing a default redirect URL or surface an error to the caller.
+            redirectToWithParams = nil
+        }
+
+        func applyBuilder(_ builder: @escaping () -> Void) async throws {
+            try await builder()
+        }
+
         switch provider {
         case .google:
             try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.Google) {
-                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if let r = redirectToWithParams { self.redirectTo = r }
                 if !scopes.isEmpty { self.scopes = scopes }
-                // TODO: map queryParams if the Kotlin builder supports it
             }
         case .github:
             try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.GitHub) {
-                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if let r = redirectToWithParams { self.redirectTo = r }
                 if !scopes.isEmpty { self.scopes = scopes }
             }
         case .apple:
             try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.Apple) {
-                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if let r = redirectToWithParams { self.redirectTo = r }
                 if !scopes.isEmpty { self.scopes = scopes }
             }
         case .gitlab:
             try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.GitLab) {
-                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if let r = redirectToWithParams { self.redirectTo = r }
                 if !scopes.isEmpty { self.scopes = scopes }
             }
         case .bitbucket:
             try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.Bitbucket) {
-                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if let r = redirectToWithParams { self.redirectTo = r }
                 if !scopes.isEmpty { self.scopes = scopes }
             }
         }

--- a/Sources/SkipSupabase/SupabaseAuth.swift
+++ b/Sources/SkipSupabase/SupabaseAuth.swift
@@ -166,7 +166,10 @@ public class AuthClient {
     // and intended for use when an OAuth provider flow requires a redirect.
     fileprivate func openURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
-        #if canImport(UIKit)
+        #if canImport(AuthenticationServices) && canImport(UIKit)
+        // Prefer ASWebAuthenticationSession on iOS for OAuth flows.
+        importAuthenticationSessionIfNeeded(url)
+        #elseif canImport(UIKit)
         DispatchQueue.main.async {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
@@ -176,6 +179,41 @@ public class AuthClient {
         // Fallback: print the URL so calling apps can handle it.
         print("Open URL: \(url.absoluteString)")
         #endif
+    }
+
+    #if canImport(AuthenticationServices) && canImport(UIKit)
+    // Use ASWebAuthenticationSession to open URL and allow the system to handle callback.
+    private func importAuthenticationSessionIfNeeded(_ url: URL) {
+        DispatchQueue.main.async {
+            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: nil) { callbackURL, error in
+                // No-op: the flow will be handled by the Supabase SDK or by the app's URL handler.
+                if let err = error {
+                    // don't crash in test
+                    print("ASWebAuthenticationSession error: \(err)")
+                }
+            }
+            session.presentationContextProvider = UIApplication.shared.connectedScenes.first as? ASWebAuthenticationPresentationContextProviding
+            session.start()
+        }
+    }
+    #endif
+
+    /// Construct the standard Supabase authorize URL for a provider and open it in the platform browser.
+    /// This is a best-effort native helper for platforms where the SDK doesn't provide a native flow.
+    public func signInWithOAuthNative(supabaseURL: URL, provider: Provider, redirectTo: String?, scopes: String = "", queryParams: [(name: String, value: String)] = []) {
+        var components = URLComponents(url: supabaseURL, resolvingAgainstBaseURL: false)
+        // Supabase authorize path is typically /auth/v1/authorize
+        components?.path = (components?.path ?? "") + "/auth/v1/authorize"
+
+        var items: [URLQueryItem] = [URLQueryItem(name: "provider", value: provider.rawValue)]
+        if let redirectTo = redirectTo { items.append(URLQueryItem(name: "redirect_to", value: redirectTo)) }
+        if !scopes.isEmpty { items.append(URLQueryItem(name: "scopes", value: scopes)) }
+        for p in queryParams { items.append(URLQueryItem(name: p.name, value: p.value)) }
+        components?.queryItems = items
+
+        if let url = components?.url {
+            openURL(url.absoluteString)
+        }
     }
 
     public func signOut(scope: SignOutScope = .global) async throws {

--- a/Sources/SkipSupabase/SupabaseAuth.swift
+++ b/Sources/SkipSupabase/SupabaseAuth.swift
@@ -85,10 +85,42 @@ public class AuthClient {
     /// if the flow requires a redirect or is not available on the current platform.
     public func signInWithOAuth(provider: Provider, redirectTo: String? = nil, scopes: String = "", queryParams: [(name: String, value: String)] = [], completion: @escaping (Session?) -> Void) async throws {
         // SKIP NOWARN
-        // Attempt to call through to the underlying Kotlin auth API if available.
-        // For the SKIP shim, provide a safe stub: call completion(nil). Real platform implementations
-        // should call the Kotlin/JS/Native provider API and invoke completion with the resulting session.
-        completion(nil)
+        // Map Provider to Kotlin provider object and invoke signInWith builder when available.
+        switch provider {
+        case .google:
+            try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.Google) {
+                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if !scopes.isEmpty { self.scopes = scopes }
+                // TODO: map queryParams if the Kotlin builder supports it
+            }
+        case .github:
+            try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.GitHub) {
+                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if !scopes.isEmpty { self.scopes = scopes }
+            }
+        case .apple:
+            try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.Apple) {
+                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if !scopes.isEmpty { self.scopes = scopes }
+            }
+        case .gitlab:
+            try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.GitLab) {
+                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if !scopes.isEmpty { self.scopes = scopes }
+            }
+        case .bitbucket:
+            try await auth.signInWith(io.github.jan.supabase.auth.providers.builtin.Bitbucket) {
+                if let redirectTo = redirectTo { self.redirectTo = redirectTo }
+                if !scopes.isEmpty { self.scopes = scopes }
+            }
+        }
+
+        // If a session was created synchronously, return it; otherwise indicate the flow requires a redirect or is incomplete.
+        if let s = auth.currentSessionOrNull() {
+            completion(Session(session: s))
+        } else {
+            completion(nil)
+        }
     }
 
     public func signOut(scope: SignOutScope = .global) async throws {

--- a/Sources/SkipSupabase/SupabaseAuth.swift
+++ b/Sources/SkipSupabase/SupabaseAuth.swift
@@ -18,6 +18,9 @@ import io.github.jan.supabase.auth.minimalSettings
 
 #if canImport(UIKit)
 import UIKit
+#if canImport(AuthenticationServices)
+import AuthenticationServices
+#endif
 #elseif canImport(AppKit)
 import AppKit
 #endif
@@ -192,8 +195,30 @@ public class AuthClient {
                     print("ASWebAuthenticationSession error: \(err)")
                 }
             }
-            session.presentationContextProvider = UIApplication.shared.connectedScenes.first as? ASWebAuthenticationPresentationContextProviding
+            session.presentationContextProvider = WebAuthPresentationContextProvider.shared
             session.start()
+        }
+    }
+
+    // Presentation context provider for ASWebAuthenticationSession. Keep a shared instance so it
+    // lives for the duration of the session.
+    private class WebAuthPresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+        static let shared = WebAuthPresentationContextProvider()
+
+        func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+            // Prefer window from connected scenes (iOS 13+), fall back to key window.
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                if let window = scene.windows.first(where: { $0.isKeyWindow }) {
+                    return window
+                }
+                return scene.windows.first ?? UIWindow()
+            }
+
+            if let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) {
+                return window
+            }
+
+            return UIWindow()
         }
     }
     #endif

--- a/Tests/SkipSupabaseAuthTests/SkipSupabaseAuthTests.swift
+++ b/Tests/SkipSupabaseAuthTests/SkipSupabaseAuthTests.swift
@@ -12,4 +12,24 @@ final class SkipSupabaseAuthTests: XCTestCase {
     func testSkipSupabaseAuth() throws {
         logger.log("running testSkipSupabaseAuth")
     }
+
+    func testSignInWithOAuthNoCrash() async throws {
+        logger.log("running testSignInWithOAuthNoCrash")
+
+        // Construct a minimal auth client using the public API. This test only ensures
+        // that calling signInWithOAuth does not crash and that the completion handler
+        // is invoked. It does not perform a real OAuth roundtrip.
+        let client = SupabaseClient(supabaseURL: URL(string: "https://example.com")!, supabaseKey: "test")
+        let ac: AuthClient = client.auth
+
+        let exp = expectation(description: "oauth-completion")
+
+        try await ac.signInWithOAuth(provider: .google, redirectTo: "https://example.com/callback", scopes: "profile", queryParams: [(name: "x", value: "y")]) { session in
+            // We expect nil in unit tests; just ensure completion runs.
+            XCTAssertNil(session)
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+    }
 }


### PR DESCRIPTION
Adds Provider enum and signInWithOAuth mapping for Google, GitHub, Apple, GitLab, Bitbucket. Appends query params to redirectTo and opens redirect URL in platform browser when flow requires redirect. Includes a unit test to ensure signInWithOAuth doesn't crash locally.